### PR TITLE
feat: add type and variable aliases for os/exec compatibility

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -7,7 +7,19 @@ import (
 	"time"
 )
 
-type ExitError = exec.ExitError
+// Type aliases for os/exec types.
+type (
+	Cmd       = exec.Cmd
+	Error     = exec.Error
+	ExitError = exec.ExitError
+)
+
+// Variable aliases for os/exec variables.
+var (
+	ErrDot       = exec.ErrDot
+	ErrNotFound  = exec.ErrNotFound
+	ErrWaitDelay = exec.ErrWaitDelay
+)
 
 // Exec represents an command executer.
 type Exec struct {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/k1LoW/exec
 
-go 1.22
+go 1.24


### PR DESCRIPTION
This pull request introduces type and variable aliases for several types and variables from the `os/exec` package, making them accessible under the current package. This change improves code clarity and allows consumers of this package to use these types and variables directly, without importing `os/exec`.

Type and variable aliasing:

* Added type aliases for `exec.Cmd`, `exec.Error`, and `exec.ExitError` as `Cmd`, `Error`, and `ExitError`, respectively.
* Added variable aliases for `exec.ErrDot`, `exec.ErrNotFound`, and `exec.ErrWaitDelay` as `ErrDot`, `ErrNotFound`, and `ErrWaitDelay`, respectively.